### PR TITLE
Alternative navigation for management

### DIFF
--- a/app/views/v17/pages/account_alt.html
+++ b/app/views/v17/pages/account_alt.html
@@ -1,0 +1,65 @@
+{% extends "../view_alt.html" %}
+
+{% block page_title %}
+  Account options - GOV.UK
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+  <!-- beta banner block -->
+  {% include "../partials/beta-banner.html" %}
+
+  <!-- navigation block -->
+  {% include "../partials/nav_head_alt.html" %}
+
+<div class="big-space"></div>
+<!--  <div class="small-space">
+    <nav id="navigate">
+
+      <div class="breadcrumbs" id="breadcrumbs">
+        <ol role="breadcrumbs">
+          <li><a href="/v17/pages/account">Account options</a></li>
+          <start comment <li><a href="">Change password</a></li> end comment>
+        </ol>
+      </div>
+    </nav>
+  </div> -->
+
+  <!-- page title -->
+  <h1  class="heading-large medium-space">Account options (alternative nav)</h1>
+
+  <div id="feature-info" class="grid-row flexy">
+
+    <div class="column-two-thirds medium-space">
+      <div class="card">
+        <!-- <h2 class="heading-medium">Reports</h2> -->
+        <ul class="list list-bullet">
+          <li>
+            <a href="contact-preferences">
+              Choose how we contact you
+            </a>
+          </li>
+          <li>
+            <a href="change_password/change_password.html">
+              Change your account password
+            </a>
+          </li>
+          <li>
+            <a href="signin.html">
+              Sign out
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+  </div>
+
+  <script src="/public/javascripts/underscore.min.js"></script>
+  <script src="/public/javascripts/jquery-1.11.3.js"></script>
+  <script src="/public/javascripts/license_results.js"></script>
+
+</main>
+{% endblock %}

--- a/app/views/v17/pages/licences_alt.html
+++ b/app/views/v17/pages/licences_alt.html
@@ -1,4 +1,4 @@
-{% extends "../view.html" %}
+{% extends "../view_alt.html" %}
 
 {% block page_title %}
   Your water abstraction or impoundment licences - GOV.UK
@@ -16,25 +16,25 @@
   </div>
 
   <!-- navigation block -->
-  {% include "../partials/nav_view.html" %}
+  {% include "../partials/nav_view_alt.html" %}
 
-  <div class="big-space">
+<div class="big-space"></div>
+<!--  <div class="big-space">
     <nav id="navigate">
-      <!-- breadcrumbs -->
       <div class="breadcrumbs" id="breadcrumbs">
         <ol role="breadcrumbs">
           <li><a href="">Your licences</a></li>
-            <!-- {{ pData.LicenceSerialNo }}</a></li> -->
+            <start comment {{ pData.LicenceSerialNo }}</a></li> end comment>
         </ol>
       </div>
     </nav>
-  </div>
+  </div> -->
 
   <!-- page title -->
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1  class="heading-large">
-        Your licences
+        Your licences (alternative nav)
       </h1>
     </div>
   </div>

--- a/app/views/v17/pages/manage_alt.html
+++ b/app/views/v17/pages/manage_alt.html
@@ -1,0 +1,73 @@
+{% extends "../view_alt.html" %}
+
+{% block page_title %}
+  Manage your licences - GOV.UK
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+  <!-- beta banner -->
+  <div class="phase-banner-beta">
+    <p>
+      <strong class="phase-tag">BETA</strong>
+      <span>This is an BETA prototype, details may be missing whilst we build the service. Your feedback will help us improve this service.</span>
+    </p>
+  </div>
+
+  <!-- navigation block -->
+  {% include "../partials/nav_manage_alt.html" %}
+
+<div class="big-space"></div>
+<!--  <div class="big-space">
+    <nav id="navigate">
+      <div class="breadcrumbs" id="breadcrumbs">
+        <ol role="breadcrumbs">
+          <li><a href="">Manage your licences</a></li>
+        </ol>
+      </div>
+    </nav>
+  </div> -->
+
+  <!-- page title -->
+  <h1  class="heading-large">Manage your licences (alternative nav)</h1>
+
+  <div id="feature-info" class="grid-row">
+
+    <div class="column-third medium-space">
+      <h2 class="heading-medium">Add licences</h2>
+      <ul class="list list-bullet">
+        <li><a href="request-access">View more of your current licences</a></li>
+        <li><a href="add_licence/auth_code">Enter a security code you've received by post</a></li>
+        <li><a href="#" target="_blank">Apply for a new abstraction or impoundment licence (opens in a new tab)</a></li>
+      </ul>
+    </div>
+
+    <div class="column-third medium-space">
+      <h2 class="heading-medium">Manage current licences</h2>
+      <ul class="list-bullet">
+        <li><a href="#">Apply to renew a licence</a></li>
+        <li><a href="#" target="_blank">Change a licence (opens in a new tab)</a></li>
+        <li><a href="#" target="_blank">Measure, record or report your water abstraction (opens in a new tab)</a></li>
+      </ul>
+    </div>
+
+    <div class="column-third big-space">
+      <h2 class="heading-medium">Share access</h2>
+      <ul class="list list-bullet">
+        <li><a href="access">Give or remove access to your licence information</a></li>
+      </ul>
+    </div>
+
+  </div>
+
+    <!-- Enter your security code
+  We sent this by post to the registered address you chose. -->
+
+  <script src="/public/javascripts/underscore.min.js"></script>
+  <script src="/public/javascripts/jquery-1.11.3.js"></script>
+  <script src="/public/javascripts/license_results.js"></script>
+
+</main>
+{% endblock %}

--- a/app/views/v17/partials/nav_head_alt.html
+++ b/app/views/v17/partials/nav_head_alt.html
@@ -1,0 +1,21 @@
+<!-- new GDS navigation pattern -->
+<div class="content-width small-space">
+  <nav id="nav" class="menu">
+
+    <div class="navbar">
+
+      <ul class="navbar__list-items menu-left">
+        <li class="navlink">
+          <a href="/v17/pages/licences_alt">View your licences</a>
+        </li>
+        <li class="navlink">
+          <a href="/v17/pages/manage_alt">Manage your licences</a>
+        </li>
+        <li class="navlink active">
+          <a href="/v17/pages/account_alt">Manage your account</a>
+        </li>
+      </ul>
+
+    </div>
+  </nav>
+</div>

--- a/app/views/v17/partials/nav_manage_alt.html
+++ b/app/views/v17/partials/nav_manage_alt.html
@@ -5,11 +5,14 @@
     <div class="navbar">
 
       <ul class="navbar__list-items menu-left">
+        <li class="navlink">
+          <a href="/v17/pages/licences_alt">View your licences</a>
+        </li>
         <li class="navlink active">
-          <a href="/v17/pages/licences">View your licences</a>
+          <a href="/v17/pages/manage_alt">Manage your licences</a>
         </li>
         <li class="navlink">
-          <a href="/v17/pages/manage">Manage your licences</a>
+          <a href="/v17/pages/account_alt">Manage your account</a>
         </li>
       </ul>
 

--- a/app/views/v17/partials/nav_view_alt.html
+++ b/app/views/v17/partials/nav_view_alt.html
@@ -6,11 +6,13 @@
 
       <ul class="navbar__list-items menu-left">
         <li class="navlink active">
-          <a href="/v17/pages/licences">View your licences</a>
+          <a href="/v17/pages/licences_alt">View your licences</a>
         </li>
         <li class="navlink">
-          <a href="/v17/pages/manage">Manage your licences</a>
+          <a href="/v17/pages/manage_alt">Manage your licences</a>
         </li>
+        <li class="navlink">
+          <a href="/v17/pages/account_alt">Manage your account</a>
       </ul>
 
     </div>

--- a/app/views/v17/view_alt.html
+++ b/app/views/v17/view_alt.html
@@ -1,0 +1,45 @@
+{% extends "govuk_template.html" %}
+
+{% block head %}
+  <link href="/public/stylesheets/application_additions.css" media="screen" rel="stylesheet" type="text/css" />
+{% endblock %}
+
+{% block cookie_message %}
+  <p>{{cookieText | safe }}</p>
+{% endblock %}
+
+{% block proposition_header %}
+
+  <div class="header-proposition">
+    <div class="content">
+      <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
+      <nav id="proposition-menu">
+        <a href="/" id="proposition-name">Manage your water abstraction or impoundment licence</a>
+      </nav>
+    </div>
+  </div>
+
+{% endblock %}
+
+{% block header_class %}
+  with-proposition
+{% endblock %}
+
+{% block content %}
+  <p>No content available</p>
+{% endblock %}
+
+{% block footer_support_links %}
+  {% if useAutoStoreData %}
+    <ul>
+      <li>
+        <a href="/prototype-admin/clear-data">Clear data</a>
+      </li>
+    </ul>
+  {% endif %}
+{% endblock %}
+
+{% block body_end %}
+  {% include "includes/scripts.html" %}
+  <!-- GOV.UK Prototype kit {{releaseVersion}} -->
+{% endblock %}

--- a/app/views/versions/v17.html
+++ b/app/views/versions/v17.html
@@ -64,7 +64,11 @@
 
       <ul class="list list-bullet">
         <li><a href="/v17/pages/licences">View licences</a></li>
+        <li><a href="/v17/pages/licences_alt">View licences (alternative)</a></li>
         <li><a href="/v17/pages/manage">Manage your licence (useful links)</a></li>
+        <li><a href="/v17/pages/manage_alt">Manage your licence (useful links) (alternative)</a></li>
+        <li><a href="/v17/pages/account">User account options</a></li>
+        <li><a href="/v17/pages/account_alt">User account options (alternative)</a></li>
         <li><a href="/v17/pages/access">Access to licences (sharing)</a></li>
       </ul>
 


### PR DESCRIPTION
I've suggested alternative navigation for the 'manage your account' page and added the links under the Information Architecture section.  Apart from additions to v17.html, I haven't changed any existing files - all new ones end with _alt.  Happy to discuss, change or discard.